### PR TITLE
Apply thiings.co-inspired theme

### DIFF
--- a/blogs/index.html
+++ b/blogs/index.html
@@ -1,92 +1,249 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Puru is an experienced DevOps Engineer, author of CKS Handbook, AWS Certified Solution Architect, CNCF Certified Kubestronaut, and a family man.">
-    <title>Puru Tuladhar – Personal Website</title>
-    <link rel="stylesheet" href="/styles.css"> <!-- Link to CSS stylesheet -->
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet"> <!-- Google Fonts -->
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Blogs by Puru Tuladhar — writing on Kubernetes, DevOps, AWS, and cloud engineering.">
+  <title>Blogs – Puru Tuladhar</title>
 
-    <!-- favicon -->
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="manifest" href="/site.webmanifest">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root {
+      --background: #ffffff;
+      --foreground: #111111;
+      --muted: #6b7280;
+      --border: #e5e7eb;
+      --muted-bg: #f9fafb;
+      --font-sans: 'Geist', system-ui, -apple-system, sans-serif;
+      --radius: 8px;
+      --transition: 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--font-sans);
+      background: var(--background);
+      color: var(--foreground);
+      -webkit-font-smoothing: antialiased;
+      font-size: 16px;
+      line-height: 1.7;
+      max-width: 680px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 4rem;
+    }
+
+    header {
+      margin-bottom: 3rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    header nav.back-nav a {
+      font-size: 14px;
+      color: var(--muted);
+      text-decoration: none;
+      font-weight: 500;
+      padding: 4px 8px;
+      border-radius: 4px;
+      transition: color var(--transition), background-color var(--transition);
+    }
+    header nav.back-nav a:hover {
+      color: var(--foreground);
+      background-color: var(--muted-bg);
+      text-decoration: none;
+    }
+
+    .page-identity {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 14px;
+      font-weight: 500;
+      color: var(--muted);
+      flex: 1;
+      justify-content: center;
+    }
+
+    .page-identity img {
+      width: 28px;
+      height: 28px;
+    }
+
+    h2 {
+      font-size: 18px;
+      font-weight: 700;
+      color: var(--foreground);
+      margin: 2.5rem 0 0.75rem;
+      letter-spacing: -0.01em;
+    }
+
+    p {
+      margin-bottom: 1rem;
+      color: #444;
+    }
+
+    a {
+      color: #326CE5;
+      text-decoration: none;
+      font-weight: 500;
+      transition: opacity var(--transition);
+    }
+    a:hover { text-decoration: underline; opacity: 0.85; }
+
+    .page-banner {
+      width: 100%;
+      border-radius: var(--radius);
+      margin-bottom: 1.75rem;
+      padding: 2rem;
+      display: flex;
+      align-items: flex-start;
+      background: var(--muted-bg);
+      border: 1px solid var(--border);
+    }
+
+    .page-banner-text {
+      color: var(--foreground);
+    }
+
+    .page-banner-text .banner-label {
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 0.75rem;
+      display: block;
+    }
+
+    .page-banner-text h1 {
+      font-size: 22px;
+      font-weight: 700;
+      color: var(--foreground);
+      line-height: 1.3;
+      margin-bottom: 0.75rem;
+      letter-spacing: -0.02em;
+    }
+
+    .page-banner-text p {
+      font-size: 14px;
+      color: #444;
+      line-height: 1.6;
+      margin-bottom: 0;
+    }
+
+    .section {
+      border-bottom: 1px solid var(--border);
+      padding-bottom: 2rem;
+      margin-bottom: 2rem;
+    }
+
+    ol {
+      padding-left: 1.4rem;
+      margin-bottom: 1rem;
+    }
+    li {
+      margin-bottom: 0.5rem;
+      color: #444;
+    }
+    li small {
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    footer {
+      margin-top: 3rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid var(--border);
+      font-size: 14px;
+      color: var(--muted);
+    }
+    footer a { color: var(--muted); font-weight: 500; }
+    footer a:hover { color: var(--foreground); text-decoration: none; }
+  </style>
 </head>
 <body>
-    <header>
-        <!-- <h1><a style='color: #333' href="/">Puru Tuladhar – Personal Website</a></h1> -->
-        
-        <div class="menu-toggle" id="mobile-menu">
-            &#9776; <!-- Hamburger icon -->
-        </div>
-        
-        <center>
-            <nav>
-                <ul id="nav-links">
-                    <li><img src="/icons/home.png" width="45px"/>&nbsp;<a href="/index.html">Home</a></li>
-                    <li><img src="/icons/blogs.png" width="40px"/>&nbsp;<a href="/blogs">Blogs</a></li>
-                    <li><img src="/icons/books.png" width="40px"/>&nbsp;<a href="/books">Books</a></li>
-                    <li><img src="/icons/open-source.png" width="40px"/>&nbsp;<a href="/open-source">Open-source</a></li>
-                    <!-- <li><a href="resume.html">My Resume</a></li> -->
-                </ul>
-            </nav>
-        </center>
-    </header>
-    <main>
-        <h3 class="blogs heading"><img src="/icons/blogs.png" width="50px"/>&nbsp;Blogs</h3>
-        <ul reversed>
-            <li><a href="https://www.linkedin.com/pulse/ditching-slack-heres-how-migrate-over-mattermost-puru-tuladhar-kiekf" target="_blank">Ditching Slack? Here's how to migrate over to Mattermost</a><small>&nbsp;– September 9, 2025</small></li>
-            <li><a href="https://ptuladhar3.medium.com/interactive-kubernetes-periodic-table-5b5eab8ebf14" target="_blank">Interactive Kubernetes Periodic Table</a><small>&nbsp;– September 7, 2025</small></li>
-            <li><a href="https://www.linkedin.com/pulse/automating-aws-cost-forecast-reports-across-puru-tuladhar-bzvcf/" target="_blank">Automating AWS Cost Forecast Reports Across Organization</a><small>&nbsp;– July 28, 2025</small></li>
-            <li><a href="https://www.linkedin.com/pulse/twenty-crms-google-integration-challenges-save-you-time-puru-tuladhar-ynzjf/" target="_blank">Twenty CRM's Google integration challenges</a><small>&nbsp;– July 17, 2025</small></li>
-            <li><a href="https://www.linkedin.com/pulse/meet-kiro-agentic-ai-ide-aws-puru-tuladhar-istff/" target="_blank">Meet Kiro - An Agentic AI IDE by AWS</a><small>&nbsp;– July 15, 2025</small></li>
-            <li><a href="https://www.linkedin.com/pulse/reduce-image-footprint-must-know-cks-exam-puru-tuladhar-oaewf/" target="_blank">Reduce Image Footprint: Must-know for CKS exam</a><small>&nbsp;– May 27, 2025</small></li>
-            <li><a href="https://www.linkedin.com/pulse/should-you-vibe-coding-puru-tuladhar-rucjf/" target="_blank">Should you be vibe coding?</a><small>&nbsp;– May 20, 2025</small></li>
-            <li><a href="https://www.linkedin.com/pulse/falco-getting-hands-on-cks-puru-tuladhar-q4yzf/" target="_blank">Falco: Getting hands-on for CKS exam</a><small>&nbsp;– May 5, 2025</small></li>
-            <li><a href="https://www.linkedin.com/pulse/falco-must-know-cks-exam-puru-tuladhar-f9tgf/" target="_blank">Falco: Must-know for CKS exam</a><small>&nbsp;– April 22, 2025</small></li>
-            <li><a href="https://www.linkedin.com/pulse/why-aws-cloud-map-better-choice-us-than-application-load-tuladhar-dd8zf/" target="_blank">Why AWS Cloud Map was a better choice for us than Application Load Balancer</a><small>&nbsp;– April 3, 2025</small></li>
-            <li><a href="https://www.linkedin.com/pulse/how-reduce-aws-nat-gateway-cost-80-puru-tuladhar-fpfnf/" target="_blank">How to reduce AWS NAT Gateway cost by 80%</a><small>&nbsp;– April 2, 2025</small></li>
-            <li><a href="https://www.linkedin.com/pulse/ingress-nginx-nightmare-cve-2025-1974-you-affected-puru-tuladhar-ithxf/" target="_blank">Ingress "NGINX" Nightmare (CVE-2025-1974) – Are you affected?</a><small>&nbsp;– March 28, 2025</small></li>
-            <li><a href="https://www.linkedin.com/pulse/cilium-network-policy-what-you-need-know-cks-puru-tuladhar-nytqf/" target="_blank">Cilium Network Policy: What You Need to Know for CKS</a><small>&nbsp;– Febuary 24, 2025</small></li>
-            <li><a href="https://www.linkedin.com/pulse/sbom-everything-you-need-know-cks-exam-puru-tuladhar-vj2cf/" target="_blank">SBOM: Everything you need to know for CKS exam</a><small>&nbsp;– January 31, 2025</small></li>
-            <li><a href="https://www.linkedin.com/pulse/3-reasons-why-chinese-ai-startup-deepseek-crash-us-stock-tuladhar-o5paf/" target="_blank">3 Reasons Why Chinese AI Startup DeepSeek Crash US Stock Market</a><small>&nbsp;– January 29, 2025</small></li>
-            <li><a href="https://www.linkedin.com/pulse/chatgpt-scheduled-tasks-your-personal-ai-agent-puru-tuladhar-eggjf" target="_blank">ChatGPT Scheduled Tasks: Your Personal AI Agent</a><small>&nbsp;– January 18, 2025</small></li>
-            <li><a href="https://www.linkedin.com/pulse/cilium-everything-you-need-know-cks-puru-tuladhar-ldpdf" target="_blank">Cilium: Everything you need to know for CKS</a><small>&nbsp;– January 16, 2025</small></li>
-            <li><a href="https://www.linkedin.com/pulse/kubestronaut-becoming-one-puru-tuladhar-lndvf" target="_blank">Kubestronaut: Becoming One</a></li>
-            <li><a href="https://www.linkedin.com/pulse/how-i-passed-kcna-kcsa-hour-puru-tuladhar-vfotf" target="_blank">How I Passed KCNA and KCSA in an Hour!</a></li>
-            <li><a href="https://www.linkedin.com/pulse/kubernetes-132-penelope-custom-resource-field-stable-puru-tuladhar-brbkf/" target="_blank">Kubernetes 1.32 "Penelope" - Custom Resource Field Selector (Stable feature)</a></li>
-            <li><a href="https://www.linkedin.com/pulse/11th-dec-2024-openai-outage-nutshell-puru-tuladhar-rus9f" target="_blank">11th Dec 2024 — OpenAI Outage (ChatGPT) Explained: Kubernetes Clusters on Fire!</a></li>
-            <li><a href="https://ptuladhar3.substack.com/p/developers-beware-rising-web3-job" target="_blank">Developers Beware - Rising Web3 Job Scam & HiveApp Malware!</a></li>
-            <li><a href="https://medium.com/@ptuladhar3/learnings-from-writing-a-kubernetes-operator-as-a-solution-architect-55de8ee2675e" target="_blank">Learning’s from writing a Kubernetes Operator as a Solution Architect</a></li>
-            <li><a href="https://medium.com/@ptuladhar3/perceptron-understanding-ai-6fbdc995fc47" target="_blank">Perceptron: Understanding AI</a></li>
-            <li><a href="https://medium.com/@ptuladhar3/avoid-using-bloated-nodejs-docker-image-in-production-a43658b5495b" target="_blank">Avoid using “bloated” Docker Image in Production! — Node.js Study Case</a></li>
-            <li><a href="https://ptuladhar.gumroad.com/l/kamal2-getting-started-from-zero" target="_blank">A Beginner's Guide to Getting Started with Kamal 2</a></li>
-            <li><a href="blogs/growing-concern-over-cloud-spending/index.html">Growing Concern over Cloud Spending</a></li>
-            <li><a href="https://medium.com/@ptuladhar3/if-i-got-a-new-mac-heres-what-i-d-install-first-as-a-devops-engineer-ae68e65801dc" target="_blank">If I Got a New Mac, Here’s What I’d Install First as a DevOps Engineer</a></li>
-            <li><a href="https://medium.com/@ptuladhar3/how-a-2-failure-turned-into-a-success-my-cks-exam-experience-3aea304f391f" target="_blank">How a 2% Failure Turned into a Success: My CKS Exam Experience</a></li>
-            <li><a href="https://ptuladhar3.medium.com/learn-kubernetes-programming-part-1-7384e5f3c481" target="_blank">Learn Kubernetes Programming — Part 1</a></li>
-            <li><a href="https://ptuladhar3.medium.com/getting-started-with-external-secrets-operator-on-kubernetes-using-aws-secrets-manager-6dc403d9630c" target="_blank">Getting Started with External Secrets Operator on Kubernetes using AWS Secrets Manager</a></li>
-            <li><a href="https://ptuladhar3.medium.com/kubernetes-distributing-pods-evenly-across-cluster-c6bdc9b49699" target="_blank">Kubernetes: Evenly Distribution of Pods Across Cluster Nodes</a></li>
-            <li><a href="https://ptuladhar3.medium.com/wireguard-vpn-monitoring-alerting-e1e1d1eaaa4e" target="_blank">Monitoring & Alerting for WireGuard VPN</a></li>
-            <li><a href="https://ptuladhar3.medium.com/github-actions-self-hosted-runner-on-kubernetes-55d077520a31" target="_blank">GitHub Actions Self-Hosted Runner on Kubernetes</a></li>
-            <li><a href="https://ptuladhar3.medium.com/schedule-mongodb-backup-to-s3-using-kubernetes-cronjob-79ca811e1fc0" target="_blank">Schedule MongoDB Backup to S3 using Kubernetes CronJob</a></li>
-            <li><a href="https://medium.com/@ptuladhar3/rocket-chat-desktop-no-valid-server-found-at-the-url-wait-what-bde80748152a" target="_blank">Rocket.Chat Desktop: No valid server found at the URL…wait what?!</a></li>
-            <li><a href="https://medium.com/@ptuladhar3/hacktoberfest-2020-day-6-my-journey-as-a-maintainer-c347367469a7" target="_blank">Hacktoberfest 2020: My journey as a maintainer</a></li>
-            <li><a href="https://medium.com/@ptuladhar3/linux-commands-for-developers-d88baba576b4" target="_blank">Linux Commands for Developers</a></li>
-            <li><a href="https://medium.com/@ptuladhar3/email-productivity-organize-your-gmail-labels-as-tabs-3c29acc7b3200" target="_blank">Email Productivity: Organize your Gmail Labels as Tabs</a></li>
-            <li><a href="https://medium.com/@ptuladhar3/deploy-scalable-and-highly-available-web-app-omaha-server-on-aws-cloud-69e26df7c85b" target="_blank">Deploy Scalable and Highly Available Web App (Omaha Server) on AWS Cloud</a></li>
-            <li><a href="https://medium.com/@ptuladhar3/design-secure-scalable-vpc-for-micro-service-architecture-1b58fbf128f4" target="_blank">Design Secure & Scalable VPC for Micro-service Architecture</a></li>
-            <li><a href="https://medium.com/@ptuladhar3/bringing-manually-created-resources-into-cloudformation-management-ffd39b05d9f6" target="_blank">Bringing Manually Created Resources Into CloudFormation Management</a></li>
-        </ul>
-    </main>
-    
-    <script src="/script.js"></script> <!-- Link to JavaScript file -->
-    <!-- Lucide icon library for web -->
-    <script src="https://unpkg.com/lucide@latest"></script>
-    <script>lucide.createIcons();</script>
-    <!-- 100% privacy-first analytics -->
-    <script async src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
+
+  <header>
+    <nav class="back-nav"><a href="/">← Back</a></nav>
+    <div class="page-identity">
+      <img src="/icons/blogs.png" alt="Blogs"/>Blogs
+    </div>
+  </header>
+
+  <div class="section">
+    <div class="page-banner">
+      <div class="page-banner-text">
+        <span class="banner-label">✍️ &nbsp;Kubernetes · AWS · DevOps · Cloud</span>
+        <h1>Writing on DevOps, Kubernetes, and cloud engineering.</h1>
+        <p>I publish regularly on LinkedIn and Medium. Topics range from Kubernetes internals and CKS exam prep to AWS cost optimisation and DevOps tooling.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>All posts</h2>
+    <ol reversed>
+      <li><a href="https://www.linkedin.com/pulse/ditching-slack-heres-how-migrate-over-mattermost-puru-tuladhar-kiekf" target="_blank">Ditching Slack? Here's how to migrate over to Mattermost</a> <small>– September 9, 2025</small></li>
+      <li><a href="https://ptuladhar3.medium.com/interactive-kubernetes-periodic-table-5b5eab8ebf14" target="_blank">Interactive Kubernetes Periodic Table</a> <small>– September 7, 2025</small></li>
+      <li><a href="https://www.linkedin.com/pulse/automating-aws-cost-forecast-reports-across-puru-tuladhar-bzvcf/" target="_blank">Automating AWS Cost Forecast Reports Across Organization</a> <small>– July 28, 2025</small></li>
+      <li><a href="https://www.linkedin.com/pulse/twenty-crms-google-integration-challenges-save-you-time-puru-tuladhar-ynzjf/" target="_blank">Twenty CRM's Google integration challenges</a> <small>– July 17, 2025</small></li>
+      <li><a href="https://www.linkedin.com/pulse/meet-kiro-agentic-ai-ide-aws-puru-tuladhar-istff/" target="_blank">Meet Kiro - An Agentic AI IDE by AWS</a> <small>– July 15, 2025</small></li>
+      <li><a href="https://www.linkedin.com/pulse/reduce-image-footprint-must-know-cks-exam-puru-tuladhar-oaewf/" target="_blank">Reduce Image Footprint: Must-know for CKS exam</a> <small>– May 27, 2025</small></li>
+      <li><a href="https://www.linkedin.com/pulse/should-you-vibe-coding-puru-tuladhar-rucjf/" target="_blank">Should you be vibe coding?</a> <small>– May 20, 2025</small></li>
+      <li><a href="https://www.linkedin.com/pulse/falco-getting-hands-on-cks-puru-tuladhar-q4yzf/" target="_blank">Falco: Getting hands-on for CKS exam</a> <small>– May 5, 2025</small></li>
+      <li><a href="https://www.linkedin.com/pulse/falco-must-know-cks-exam-puru-tuladhar-f9tgf/" target="_blank">Falco: Must-know for CKS exam</a> <small>– April 22, 2025</small></li>
+      <li><a href="https://www.linkedin.com/pulse/why-aws-cloud-map-better-choice-us-than-application-load-tuladhar-dd8zf/" target="_blank">Why AWS Cloud Map was a better choice for us than Application Load Balancer</a> <small>– April 3, 2025</small></li>
+      <li><a href="https://www.linkedin.com/pulse/how-reduce-aws-nat-gateway-cost-80-puru-tuladhar-fpfnf/" target="_blank">How to reduce AWS NAT Gateway cost by 80%</a> <small>– April 2, 2025</small></li>
+      <li><a href="https://www.linkedin.com/pulse/ingress-nginx-nightmare-cve-2025-1974-you-affected-puru-tuladhar-ithxf/" target="_blank">Ingress "NGINX" Nightmare (CVE-2025-1974) – Are you affected?</a> <small>– March 28, 2025</small></li>
+      <li><a href="https://www.linkedin.com/pulse/cilium-network-policy-what-you-need-know-cks-puru-tuladhar-nytqf/" target="_blank">Cilium Network Policy: What You Need to Know for CKS</a> <small>– February 24, 2025</small></li>
+      <li><a href="https://www.linkedin.com/pulse/sbom-everything-you-need-know-cks-exam-puru-tuladhar-vj2cf/" target="_blank">SBOM: Everything you need to know for CKS exam</a> <small>– January 31, 2025</small></li>
+      <li><a href="https://www.linkedin.com/pulse/3-reasons-why-chinese-ai-startup-deepseek-crash-us-stock-tuladhar-o5paf/" target="_blank">3 Reasons Why Chinese AI Startup DeepSeek Crash US Stock Market</a> <small>– January 29, 2025</small></li>
+      <li><a href="https://www.linkedin.com/pulse/chatgpt-scheduled-tasks-your-personal-ai-agent-puru-tuladhar-eggjf" target="_blank">ChatGPT Scheduled Tasks: Your Personal AI Agent</a> <small>– January 18, 2025</small></li>
+      <li><a href="https://www.linkedin.com/pulse/cilium-everything-you-need-know-cks-puru-tuladhar-ldpdf" target="_blank">Cilium: Everything you need to know for CKS</a> <small>– January 16, 2025</small></li>
+      <li><a href="https://www.linkedin.com/pulse/kubestronaut-becoming-one-puru-tuladhar-lndvf" target="_blank">Kubestronaut: Becoming One</a></li>
+      <li><a href="https://www.linkedin.com/pulse/how-i-passed-kcna-kcsa-hour-puru-tuladhar-vfotf" target="_blank">How I Passed KCNA and KCSA in an Hour!</a></li>
+      <li><a href="https://www.linkedin.com/pulse/kubernetes-132-penelope-custom-resource-field-stable-puru-tuladhar-brbkf/" target="_blank">Kubernetes 1.32 "Penelope" - Custom Resource Field Selector (Stable feature)</a></li>
+      <li><a href="https://www.linkedin.com/pulse/11th-dec-2024-openai-outage-nutshell-puru-tuladhar-rus9f" target="_blank">11th Dec 2024 — OpenAI Outage (ChatGPT) Explained: Kubernetes Clusters on Fire!</a></li>
+      <li><a href="https://ptuladhar3.substack.com/p/developers-beware-rising-web3-job" target="_blank">Developers Beware - Rising Web3 Job Scam & HiveApp Malware!</a></li>
+      <li><a href="https://medium.com/@ptuladhar3/learnings-from-writing-a-kubernetes-operator-as-a-solution-architect-55de8ee2675e" target="_blank">Learning's from writing a Kubernetes Operator as a Solution Architect</a></li>
+      <li><a href="https://medium.com/@ptuladhar3/perceptron-understanding-ai-6fbdc995fc47" target="_blank">Perceptron: Understanding AI</a></li>
+      <li><a href="https://medium.com/@ptuladhar3/avoid-using-bloated-nodejs-docker-image-in-production-a43658b5495b" target="_blank">Avoid using "bloated" Docker Image in Production! — Node.js Study Case</a></li>
+      <li><a href="https://ptuladhar.gumroad.com/l/kamal2-getting-started-from-zero" target="_blank">A Beginner's Guide to Getting Started with Kamal 2</a></li>
+      <li><a href="/blogs/growing-concern-over-cloud-spending/index.html">Growing Concern over Cloud Spending</a></li>
+      <li><a href="https://medium.com/@ptuladhar3/if-i-got-a-new-mac-heres-what-i-d-install-first-as-a-devops-engineer-ae68e65801dc" target="_blank">If I Got a New Mac, Here's What I'd Install First as a DevOps Engineer</a></li>
+      <li><a href="https://medium.com/@ptuladhar3/how-a-2-failure-turned-into-a-success-my-cks-exam-experience-3aea304f391f" target="_blank">How a 2% Failure Turned into a Success: My CKS Exam Experience</a></li>
+      <li><a href="https://ptuladhar3.medium.com/learn-kubernetes-programming-part-1-7384e5f3c481" target="_blank">Learn Kubernetes Programming — Part 1</a></li>
+      <li><a href="https://ptuladhar3.medium.com/getting-started-with-external-secrets-operator-on-kubernetes-using-aws-secrets-manager-6dc403d9630c" target="_blank">Getting Started with External Secrets Operator on Kubernetes using AWS Secrets Manager</a></li>
+      <li><a href="https://ptuladhar3.medium.com/kubernetes-distributing-pods-evenly-across-cluster-c6bdc9b49699" target="_blank">Kubernetes: Evenly Distribution of Pods Across Cluster Nodes</a></li>
+      <li><a href="https://ptuladhar3.medium.com/wireguard-vpn-monitoring-alerting-e1e1d1eaaa4e" target="_blank">Monitoring & Alerting for WireGuard VPN</a></li>
+      <li><a href="https://ptuladhar3.medium.com/github-actions-self-hosted-runner-on-kubernetes-55d077520a31" target="_blank">GitHub Actions Self-Hosted Runner on Kubernetes</a></li>
+      <li><a href="https://ptuladhar3.medium.com/schedule-mongodb-backup-to-s3-using-kubernetes-cronjob-79ca811e1fc0" target="_blank">Schedule MongoDB Backup to S3 using Kubernetes CronJob</a></li>
+      <li><a href="https://medium.com/@ptuladhar3/rocket-chat-desktop-no-valid-server-found-at-the-url-wait-what-bde80748152a" target="_blank">Rocket.Chat Desktop: No valid server found at the URL…wait what?!</a></li>
+      <li><a href="https://medium.com/@ptuladhar3/hacktoberfest-2020-day-6-my-journey-as-a-maintainer-c347367469a7" target="_blank">Hacktoberfest 2020: My journey as a maintainer</a></li>
+      <li><a href="https://medium.com/@ptuladhar3/linux-commands-for-developers-d88baba576b4" target="_blank">Linux Commands for Developers</a></li>
+      <li><a href="https://medium.com/@ptuladhar3/email-productivity-organize-your-gmail-labels-as-tabs-3c29acc7b3200" target="_blank">Email Productivity: Organize your Gmail Labels as Tabs</a></li>
+      <li><a href="https://medium.com/@ptuladhar3/deploy-scalable-and-highly-available-web-app-omaha-server-on-aws-cloud-69e26df7c85b" target="_blank">Deploy Scalable and Highly Available Web App (Omaha Server) on AWS Cloud</a></li>
+      <li><a href="https://medium.com/@ptuladhar3/design-secure-scalable-vpc-for-micro-service-architecture-1b58fbf128f4" target="_blank">Design Secure & Scalable VPC for Micro-service Architecture</a></li>
+      <li><a href="https://medium.com/@ptuladhar3/bringing-manually-created-resources-into-cloudformation-management-ffd39b05d9f6" target="_blank">Bringing Manually Created Resources Into CloudFormation Management</a></li>
+    </ol>
+  </div>
+
+  <footer>
+    <p>
+      Made by <a href="/">Puru Tuladhar</a> ·
+      <a href="mailto:hello@purutuladhar.com">hello@purutuladhar.com</a> ·
+      <a href="https://www.linkedin.com/in/ptuladhar3/" target="_blank">LinkedIn</a> ·
+      <a href="https://x.com/ptuladhar3" target="_blank">X</a>
+    </p>
+  </footer>
+
+  <script async src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
 </body>
 </html>

--- a/books/index.html
+++ b/books/index.html
@@ -1,49 +1,214 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Puru is an experienced DevOps Engineer, author of CKS Handbook, AWS Certified Solution Architect, CNCF Certified Kubestronaut, and a family man.">
-    <title>Puru Tuladhar – Personal Website</title>
-    <link rel="stylesheet" href="/styles.css"> <!-- Link to CSS stylesheet -->
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet"> <!-- Google Fonts -->
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Books by Puru Tuladhar — CKA Handbook, CKS Handbook, AWS cheatsheets, Kamal 2 guide, and more.">
+  <title>Books – Puru Tuladhar</title>
+
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root {
+      --background: #ffffff;
+      --foreground: #111111;
+      --muted: #6b7280;
+      --border: #e5e7eb;
+      --muted-bg: #f9fafb;
+      --font-sans: 'Geist', system-ui, -apple-system, sans-serif;
+      --radius: 8px;
+      --transition: 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--font-sans);
+      background: var(--background);
+      color: var(--foreground);
+      -webkit-font-smoothing: antialiased;
+      font-size: 16px;
+      line-height: 1.7;
+      max-width: 680px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 4rem;
+    }
+
+    header {
+      margin-bottom: 3rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    header nav.back-nav a {
+      font-size: 14px;
+      color: var(--muted);
+      text-decoration: none;
+      font-weight: 500;
+      padding: 4px 8px;
+      border-radius: 4px;
+      transition: color var(--transition), background-color var(--transition);
+    }
+    header nav.back-nav a:hover {
+      color: var(--foreground);
+      background-color: var(--muted-bg);
+      text-decoration: none;
+    }
+
+    .page-identity {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 14px;
+      font-weight: 500;
+      color: var(--muted);
+      flex: 1;
+      justify-content: center;
+    }
+
+    .page-identity img {
+      width: 28px;
+      height: 28px;
+    }
+
+    h2 {
+      font-size: 18px;
+      font-weight: 700;
+      color: var(--foreground);
+      margin: 2.5rem 0 0.75rem;
+      letter-spacing: -0.01em;
+    }
+
+    p {
+      margin-bottom: 1rem;
+      color: #444;
+    }
+
+    a {
+      color: #326CE5;
+      text-decoration: none;
+      font-weight: 500;
+      transition: opacity var(--transition);
+    }
+    a:hover { text-decoration: underline; opacity: 0.85; }
+
+    .page-banner {
+      width: 100%;
+      border-radius: var(--radius);
+      margin-bottom: 1.75rem;
+      padding: 2rem;
+      display: flex;
+      align-items: flex-start;
+      background: var(--muted-bg);
+      border: 1px solid var(--border);
+    }
+
+    .page-banner-text {
+      color: var(--foreground);
+    }
+
+    .page-banner-text .banner-label {
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 0.75rem;
+      display: block;
+    }
+
+    .page-banner-text h1 {
+      font-size: 22px;
+      font-weight: 700;
+      color: var(--foreground);
+      line-height: 1.3;
+      margin-bottom: 0.75rem;
+      letter-spacing: -0.02em;
+    }
+
+    .page-banner-text p {
+      font-size: 14px;
+      color: #444;
+      line-height: 1.6;
+      margin-bottom: 0;
+    }
+
+    .section {
+      border-bottom: 1px solid var(--border);
+      padding-bottom: 2rem;
+      margin-bottom: 2rem;
+    }
+
+    ul {
+      padding-left: 1.4rem;
+      margin-bottom: 1rem;
+    }
+    li {
+      margin-bottom: 0.5rem;
+      color: #444;
+    }
+    li small {
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    footer {
+      margin-top: 3rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid var(--border);
+      font-size: 14px;
+      color: var(--muted);
+    }
+    footer a { color: var(--muted); font-weight: 500; }
+    footer a:hover { color: var(--foreground); text-decoration: none; }
+  </style>
 </head>
 <body>
-    <header>
-        <!-- <h1><a style='color: #333' href="/">Puru Tuladhar – Personal Website</a></h1> -->
-        
-        <div class="menu-toggle" id="mobile-menu">
-            &#9776; <!-- Hamburger icon -->
-        </div>
-        
-        <center>
-            <nav>
-                <ul id="nav-links">
-                    <li><img src="/icons/home.png" width="45px"/>&nbsp;<a href="/index.html">Home</a></li>
-                    <li><img src="/icons/blogs.png" width="40px"/>&nbsp;<a href="/blogs">Blogs</a></li>
-                    <li><img src="/icons/books.png" width="40px"/>&nbsp;<a href="/books">Books</a></li>
-                    <li><img src="/icons/open-source.png" width="40px"/>&nbsp;<a href="/open-source">Open-source</a></li>
-                    <!-- <li><a href="resume.html">My Resume</a></li> -->
-                </ul>
-            </nav>
-        </center>
-    </header>
-    <main>
-        <h3 class="heading"><img src="/icons/books.png"/>&nbsp;Books</h3>
-        <ul>
-            <li><a href="https://cka.purutuladhar.com" target="_blank">Certified Kubernetes Administrator (CKA) Handbook</a><small>&nbsp;– New!</small></li>
-            <li><a href="https://cks.purutuladhar.com" target="_blank">Certified Kubernetes Security Specialist (CKS) Handbook</a><small>&nbsp;– 300+ copies sold.</small></li>
-            <li><a href="https://kamal.purutuladhar.com" target="_blank">A Beginner's Guide to Getting Started with Kamal 2</a><small>&nbsp;– 100+ copies sold.</small></li>
-            <li><a href="https://sap.purutuladhar.com" target="_blank">AWS Certified Solutions Architect Professional — Cheatsheet</a><small>&nbsp;– 75+ copies sold.</small></li>
-            <li><a href="https://saa.purutuladhar.com" target="_blank">AWS Certified Solution Architect Associate — Cheatsheet</a><small>&nbsp;– 50+ copies sold.</small></li>
-            <li><a href='https://cursor.purutuladhar.com'>A Beginner's Guide to Using Cursor — The AI Code Editor</a><small>&nbsp;– 15+ copies sold.</small></li>
-            <li><a href='https://awsmadesimple.purutuladhar.com'>AWS Made Simple — Your Quick Guide To The Cloud</a><small>&nbsp;– New!</small></li>
-        </ul>
-    </main>
-    <script src="/script.js"></script> <!-- Link to JavaScript file -->
-    <!-- Lucide icon library for web -->
-    <script src="https://unpkg.com/lucide@latest"></script>
-    <script>lucide.createIcons();</script>    
-    <!-- 100% privacy-first analytics -->
-    <script async src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
+
+  <header>
+    <nav class="back-nav"><a href="/">← Back</a></nav>
+    <div class="page-identity">
+      <img src="/icons/books.png" alt="Books"/>Books
+    </div>
+  </header>
+
+  <div class="section">
+    <div class="page-banner">
+      <div class="page-banner-text">
+        <span class="banner-label">📚 &nbsp;Kubernetes · AWS · DevOps</span>
+        <h1>Books and guides I've written.</h1>
+        <p>Hands-on handbooks and cheatsheets for Kubernetes certifications, AWS, and DevOps tooling — used by thousands of engineers.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>All books</h2>
+    <ul>
+      <li><a href="https://cka.purutuladhar.com" target="_blank">Certified Kubernetes Administrator (CKA) Handbook</a> <small>– New!</small></li>
+      <li><a href="https://cks.purutuladhar.com" target="_blank">Certified Kubernetes Security Specialist (CKS) Handbook</a> <small>– 300+ copies sold.</small></li>
+      <li><a href="https://kamal.purutuladhar.com" target="_blank">A Beginner's Guide to Getting Started with Kamal 2</a> <small>– 100+ copies sold.</small></li>
+      <li><a href="https://sap.purutuladhar.com" target="_blank">AWS Certified Solutions Architect Professional — Cheatsheet</a> <small>– 75+ copies sold.</small></li>
+      <li><a href="https://saa.purutuladhar.com" target="_blank">AWS Certified Solution Architect Associate — Cheatsheet</a> <small>– 50+ copies sold.</small></li>
+      <li><a href="https://cursor.purutuladhar.com" target="_blank">A Beginner's Guide to Using Cursor — The AI Code Editor</a> <small>– 15+ copies sold.</small></li>
+      <li><a href="https://awsmadesimple.purutuladhar.com" target="_blank">AWS Made Simple — Your Quick Guide To The Cloud</a> <small>– New!</small></li>
+    </ul>
+  </div>
+
+  <footer>
+    <p>
+      Made by <a href="/">Puru Tuladhar</a> ·
+      <a href="mailto:hello@purutuladhar.com">hello@purutuladhar.com</a> ·
+      <a href="https://www.linkedin.com/in/ptuladhar3/" target="_blank">LinkedIn</a> ·
+      <a href="https://x.com/ptuladhar3" target="_blank">X</a>
+    </p>
+  </footer>
+
+  <script async src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
 </body>
 </html>

--- a/devops/index.html
+++ b/devops/index.html
@@ -12,15 +12,26 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest">
 
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 
   <style>
+    :root {
+      --background: #ffffff;
+      --foreground: #111111;
+      --muted: #6b7280;
+      --border: #e5e7eb;
+      --muted-bg: #f9fafb;
+      --font-sans: 'Geist', system-ui, -apple-system, sans-serif;
+      --radius: 8px;
+      --transition: 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+    }
     * { box-sizing: border-box; margin: 0; padding: 0; }
 
     body {
-      font-family: 'Inter', sans-serif;
-      background: #fff;
-      color: #333;
+      font-family: var(--font-sans);
+      background: var(--background);
+      color: var(--foreground);
+      -webkit-font-smoothing: antialiased;
       font-size: 16px;
       line-height: 1.7;
       max-width: 680px;
@@ -30,28 +41,57 @@
 
     header {
       margin-bottom: 3rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
     }
 
-    header nav a {
+    header nav.back-nav a {
       font-size: 14px;
-      color: #888;
+      color: var(--muted);
+      text-decoration: none;
+      font-weight: 500;
+      padding: 4px 8px;
+      border-radius: 4px;
+      transition: color var(--transition), background-color var(--transition);
+    }
+    header nav.back-nav a:hover {
+      color: var(--foreground);
+      background-color: var(--muted-bg);
       text-decoration: none;
     }
-    header nav a:hover { color: #333; }
+
+    .page-identity {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 14px;
+      font-weight: 500;
+      color: var(--muted);
+      flex: 1;
+      justify-content: center;
+    }
+
+    .page-identity img {
+      width: 28px;
+      height: 28px;
+    }
 
     h1 {
       font-size: 22px;
       font-weight: 700;
-      color: #111;
+      color: var(--foreground);
       margin-bottom: 0.5rem;
       line-height: 1.3;
+      letter-spacing: -0.02em;
     }
 
     h2 {
       font-size: 18px;
       font-weight: 700;
-      color: #111;
+      color: var(--foreground);
       margin: 2.5rem 0 0.75rem;
+      letter-spacing: -0.01em;
     }
 
     p {
@@ -60,27 +100,69 @@
     }
 
     a {
-      color: #0066cc;
+      color: #326CE5;
       text-decoration: none;
+      font-weight: 500;
+      transition: opacity var(--transition);
     }
-    a:hover { text-decoration: underline; }
+    a:hover { text-decoration: underline; opacity: 0.85; }
 
-    .avatar {
-      width: 80px;
-      height: 80px;
-      border-radius: 50%;
-      margin-bottom: 1rem;
+    .page-banner {
+      width: 100%;
+      border-radius: var(--radius);
+      margin-bottom: 1.75rem;
+      padding: 2rem 2rem;
+      display: flex;
+      align-items: flex-start;
+      background: var(--muted-bg);
+      border: 1px solid var(--border);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .page-banner-text {
+      position: relative;
+      color: var(--foreground);
+    }
+
+    .page-banner-text .banner-label {
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 0.75rem;
       display: block;
     }
 
+    .page-banner-text h1 {
+      font-size: 22px;
+      font-weight: 700;
+      color: var(--foreground);
+      line-height: 1.3;
+      margin-bottom: 0.75rem;
+    }
+
+    .page-banner-text p {
+      font-size: 14px;
+      color: #444;
+      line-height: 1.6;
+      margin-bottom: 0;
+    }
+
+    .page-banner-text a {
+      color: #326CE5;
+      text-underline-offset: 2px;
+    }
+
     .intro {
-      border-bottom: 1px solid #eee;
+      border-bottom: 1px solid var(--border);
       padding-bottom: 2rem;
       margin-bottom: 2rem;
     }
 
     .section {
-      border-bottom: 1px solid #eee;
+      border-bottom: 1px solid var(--border);
       padding-bottom: 2rem;
       margin-bottom: 2rem;
     }
@@ -103,30 +185,30 @@
     .pricing-table th {
       text-align: left;
       padding: 8px 12px;
-      background: #f7f7f7;
-      border: 1px solid #e5e5e5;
-      font-weight: 700;
-      color: #111;
+      background: var(--muted-bg);
+      border: 1px solid var(--border);
+      font-weight: 600;
+      color: var(--foreground);
     }
     .pricing-table td {
       padding: 8px 12px;
-      border: 1px solid #e5e5e5;
+      border: 1px solid var(--border);
       color: #444;
       vertical-align: top;
     }
-    .pricing-table tr:hover td { background: #fafafa; }
+    .pricing-table tr:hover td { background: var(--muted-bg); }
 
     .note {
       font-size: 14px;
-      color: #888;
+      color: var(--muted);
       font-style: italic;
     }
 
     .form-section label {
       display: block;
       font-size: 14px;
-      font-weight: 700;
-      color: #333;
+      font-weight: 600;
+      color: var(--foreground);
       margin-bottom: 4px;
       margin-top: 1rem;
     }
@@ -134,18 +216,20 @@
     .form-section textarea,
     .form-section select {
       width: 100%;
-      border: 1px solid #ccc;
-      border-radius: 4px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
       padding: 8px 10px;
       font-size: 14px;
-      font-family: 'Inter', sans-serif;
-      color: #333;
+      font-family: var(--font-sans);
+      color: var(--foreground);
+      background: var(--background);
       outline: none;
+      transition: border-color var(--transition);
     }
     .form-section input:focus,
     .form-section textarea:focus,
     .form-section select:focus {
-      border-color: #0066cc;
+      border-color: #326CE5;
     }
     .form-section textarea { resize: vertical; min-height: 80px; }
 
@@ -153,25 +237,26 @@
       display: flex;
       gap: 0;
       margin-bottom: 1.5rem;
-      border-bottom: 2px solid #eee;
+      border-bottom: 1px solid var(--border);
     }
     .form-tab {
       padding: 8px 18px;
       font-size: 14px;
-      font-weight: 700;
-      color: #888;
+      font-weight: 600;
+      color: var(--muted);
       cursor: pointer;
       border-bottom: 2px solid transparent;
-      margin-bottom: -2px;
+      margin-bottom: -1px;
       background: none;
       border-top: none;
       border-left: none;
       border-right: none;
-      font-family: 'Inter', sans-serif;
+      font-family: var(--font-sans);
+      transition: color var(--transition);
     }
     .form-tab.active {
-      color: #111;
-      border-bottom: 2px solid #111;
+      color: var(--foreground);
+      border-bottom: 2px solid var(--foreground);
     }
 
     .form-panel { display: none; }
@@ -180,45 +265,54 @@
     .btn {
       display: inline-block;
       margin-top: 1rem;
-      padding: 10px 20px;
-      background: #111;
+      padding: 9px 20px;
+      background: var(--foreground);
       color: #fff;
       font-size: 14px;
-      font-weight: 700;
+      font-weight: 600;
       border: none;
-      border-radius: 4px;
+      border-radius: 6px;
       cursor: pointer;
-      font-family: 'Inter', sans-serif;
+      font-family: var(--font-sans);
+      transition: opacity var(--transition), transform var(--transition);
     }
-    .btn:hover { background: #333; }
+    .btn:hover { opacity: 0.85; }
+    .btn:active { transform: scale(0.97); }
 
     footer {
       margin-top: 3rem;
       padding-top: 1.5rem;
-      border-top: 1px solid #eee;
+      border-top: 1px solid var(--border);
       font-size: 14px;
-      color: #888;
+      color: var(--muted);
     }
-    footer a { color: #888; }
-    footer a:hover { color: #333; }
+    footer a { color: var(--muted); font-weight: 500; }
+    footer a:hover { color: var(--foreground); text-decoration: none; }
   </style>
 </head>
 <body>
 
-  <header>
-    <nav><a href="/">← purutuladhar.com</a></nav>
+  <header style="position: relative;">
+    <nav class="back-nav"><a href="/">← Back</a></nav>
+    <div class="page-identity">
+      <img src="/icons/devops-engineer.png" alt="Hire"/>Hire
+    </div>
   </header>
 
   <!-- INTRO -->
   <div class="intro">
-    <img src="/avatar.png" alt="Puru Tuladhar" class="avatar">
-    <h1>I help Nepal companies hire &amp; grow DevOps engineers.</h1>
-    <p>
-      Hi, I'm Puru. I'm a DevOps engineer, <a href="https://www.credly.com/badges/bd57b314-30a5-48e0-836a-19f9cf6ddf61" target="_blank">CNCF Kubestronaut</a>,
-      <a href="https://www.credly.com/users/puru-tuladhar" target="_blank">AWS Certified Solutions Architect</a>,
-      and author of the <a href="https://cka.purutuladhar.com" target="_blank">CKA</a> and <a href="https://cks.purutuladhar.com" target="_blank">CKS Handbooks</a>.
-      I've spent 10+ years building infrastructure and systems on the internet.
-    </p>
+    <div class="page-banner">
+      <div class="page-banner-text">
+        <span class="banner-label">⚙️ &nbsp;DevOps · Infrastructure · Nepal</span>
+        <h1>I help Nepal companies hire &amp; grow DevOps engineers.</h1>
+        <p>
+          Hi, I'm Puru. I'm a DevOps engineer, <a href="https://www.credly.com/badges/bd57b314-30a5-48e0-836a-19f9cf6ddf61" target="_blank">CNCF Kubestronaut</a>,
+          <a href="https://www.credly.com/users/puru-tuladhar" target="_blank">AWS Certified Solutions Architect</a>,
+          and author of the <a href="https://cka.purutuladhar.com" target="_blank">CKA</a> and <a href="https://cks.purutuladhar.com" target="_blank">CKS Handbooks</a>.
+          I've spent 10+ years building infrastructure and systems on the internet.
+        </p>
+      </div>
+    </div>
     <p>
       I started this because I kept seeing the same thing: good companies in Nepal struggling to hire DevOps talent,
       and good engineers struggling to grow without proper mentorship. Generic job boards don't solve either problem.

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
     }
     </script>
     <link rel="stylesheet" href="styles.css"> <!-- Link to CSS stylesheet -->
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet"> <!-- Google Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"> Font Awesome for icons -->
 
     <!-- favicon -->

--- a/open-source/index.html
+++ b/open-source/index.html
@@ -1,59 +1,223 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Puru is an experienced DevOps Engineer, author of CKS Handbook, AWS Certified Solution Architect, CNCF Certified Kubestronaut, and a family man.">
-    <title>Puru Tuladhar – Personal Website</title>
-    <link rel="stylesheet" href="/styles.css"> <!-- Link to CSS stylesheet -->
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet"> <!-- Google Fonts -->
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Open-source projects by Puru Tuladhar — DevOps tools, Kubernetes operators, AWS utilities, and more.">
+  <title>Open-source – Puru Tuladhar</title>
+
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root {
+      --background: #ffffff;
+      --foreground: #111111;
+      --muted: #6b7280;
+      --border: #e5e7eb;
+      --muted-bg: #f9fafb;
+      --font-sans: 'Geist', system-ui, -apple-system, sans-serif;
+      --radius: 8px;
+      --transition: 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--font-sans);
+      background: var(--background);
+      color: var(--foreground);
+      -webkit-font-smoothing: antialiased;
+      font-size: 16px;
+      line-height: 1.7;
+      max-width: 680px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 4rem;
+    }
+
+    header {
+      margin-bottom: 3rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    header nav.back-nav a {
+      font-size: 14px;
+      color: var(--muted);
+      text-decoration: none;
+      font-weight: 500;
+      padding: 4px 8px;
+      border-radius: 4px;
+      transition: color var(--transition), background-color var(--transition);
+    }
+    header nav.back-nav a:hover {
+      color: var(--foreground);
+      background-color: var(--muted-bg);
+      text-decoration: none;
+    }
+
+    .page-identity {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 14px;
+      font-weight: 500;
+      color: var(--muted);
+      flex: 1;
+      justify-content: center;
+    }
+
+    .page-identity img {
+      width: 28px;
+      height: 28px;
+    }
+
+    h2 {
+      font-size: 18px;
+      font-weight: 700;
+      color: var(--foreground);
+      margin: 2.5rem 0 0.75rem;
+      letter-spacing: -0.01em;
+    }
+
+    p {
+      margin-bottom: 1rem;
+      color: #444;
+    }
+
+    a {
+      color: #326CE5;
+      text-decoration: none;
+      font-weight: 500;
+      transition: opacity var(--transition);
+    }
+    a:hover { text-decoration: underline; opacity: 0.85; }
+
+    .page-banner {
+      width: 100%;
+      border-radius: var(--radius);
+      margin-bottom: 1.75rem;
+      padding: 2rem;
+      display: flex;
+      align-items: flex-start;
+      background: var(--muted-bg);
+      border: 1px solid var(--border);
+    }
+
+    .page-banner-text {
+      color: var(--foreground);
+    }
+
+    .page-banner-text .banner-label {
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 0.75rem;
+      display: block;
+    }
+
+    .page-banner-text h1 {
+      font-size: 22px;
+      font-weight: 700;
+      color: var(--foreground);
+      line-height: 1.3;
+      margin-bottom: 0.75rem;
+      letter-spacing: -0.02em;
+    }
+
+    .page-banner-text p {
+      font-size: 14px;
+      color: #444;
+      line-height: 1.6;
+      margin-bottom: 0;
+    }
+
+    .section {
+      border-bottom: 1px solid var(--border);
+      padding-bottom: 2rem;
+      margin-bottom: 2rem;
+    }
+
+    ul {
+      padding-left: 1.4rem;
+      margin-bottom: 1rem;
+    }
+    li {
+      margin-bottom: 0.5rem;
+      color: #444;
+    }
+
+    .abandoned a {
+      text-decoration: line-through;
+      opacity: 0.5;
+    }
+
+    footer {
+      margin-top: 3rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid var(--border);
+      font-size: 14px;
+      color: var(--muted);
+    }
+    footer a { color: var(--muted); font-weight: 500; }
+    footer a:hover { color: var(--foreground); text-decoration: none; }
+  </style>
 </head>
 <body>
-    <header>
-        <!-- <h1><a style='color: #333' href="/">Puru Tuladhar – Personal Website</a></h1> -->
-        
-        <div class="menu-toggle" id="mobile-menu">
-            &#9776; <!-- Hamburger icon -->
-        </div>
-        
-        <center>
-            <nav>
-                <ul id="nav-links">
-                    <li><img src="/icons/home.png" width="45px"/>&nbsp;<a href="/index.html">Home</a></li>
-                    <li><img src="/icons/blogs.png" width="40px"/>&nbsp;<a href="/blogs">Blogs</a></li>
-                    <li><img src="/icons/books.png" width="40px"/>&nbsp;<a href="/books">Books</a></li>
-                    <li><img src="/icons/open-source.png" width="40px"/>&nbsp;<a href="/open-source">Open-source</a></li>
-                    <!-- <li><a href="resume.html">My Resume</a></li> -->
-                </ul>
-            </nav>
-        </center>
-    </header>
-    <main>
-        <h3 class="heading"><img src="/icons/open-source.png" width="50px"/>&nbsp;Open-source</h3>
-        <ul>
-            <li><a href='https://github.com/tuladhar/adns-ruby'>adns-ruby</a>&nbsp;–&nbsp;Ruby-interface to GNU adns library, written in C.</li>
-            <li><a href='https://github.com/tuladhar/cleanup-aws-access-keys'>cleanup-aws-access-key</a>&nbsp;–&nbsp;Clean unused AWS access keys, written in Go.</li>
-            <li><a href='https://github.com/tuladhar/gmail-labels-as-tabs'>gmail-labels-as-tabs</a>&nbsp;–&nbsp;Chrome extension to organize Gmail inbox, written in Javascript.</li>
-            <li><a href='https://github.com/tuladhar/ssl-handshake'>ssl-handshake</a>&nbsp;–&nbsp;SSL/TLS handshake latency testing tool, written in Go.</li>
-            <li><a href='https://github.com/giantswarm/teleport-operator'>teleport-operator</a>&nbsp;–&nbsp;Kubernetes operator for Teleport, written in Go.</li>
-            <li><a href='https://github.com/tuladhar/aws-whats-new-bot'>aws-whats-new-bot</a>&nbsp;–&nbsp;Twitter bot for posting AWS news, written in Go.</li>
-            <li><a href='https://github.com/tuladhar/cfradarnp'>cfradarnp</a>&nbsp;–&nbsp;Twitter bot for posting Internet trends for Nepal, written in Python, Javascript.</li>
-            <li><a href='https://github.com/tuladhar/k8s-backup-mongodb'>k8s-backup-mongodb</a>&nbsp;–&nbsp;Schedules MongoDB backup to AWS S3 using Kubernetes CronJob.</li>
-            <li class='abandoned'><a href="https://jobpayena.fyi">jobpayena.fyi</a> – Tracking tech jobs in Nepal (Kamal, NocoDB).</li>
-            <li class='abandoned'><a href="https://certs.discount">certs.discount</a> – Making tech certifications affordable (Kamal, NocoDB).</li>
-            <li><a href="https://himalisamay.com">himalisamay.com</a> – Official Himali Samay Website - Nepali Brand Watches.</li>
-            <li><a href="https://quiz.purutuladhar.com/">quiz.purutuladhar.com</a> - Free Cloud Certifications Quiz</a>.</li>
-            <li><a href='https://k8s-issues.purutuladhar.com'>k8s-issues.purutuladhar.com</a> - Kubernetes Production Issues Explorer.</li>
-            <li><a href='https://purutuladhar.com/kubernetes-periodic-table'>kubernetes-periodic-table</a> - Interactive Kubernetes Periodic Table.</li>
-            <p style="margin-top: 0px">and <a href="https://github.com/tuladhar">many more.</a></p>
-        </ul>
 
-    </main>
-    
-    <script src="/script.js"></script> <!-- Link to JavaScript file -->
-    <!-- Lucide icon library for web -->
-    <script src="https://unpkg.com/lucide@latest"></script>
-    <script>lucide.createIcons();</script>    
-    <!-- 100% privacy-first analytics -->
-    <script async src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
+  <header>
+    <nav class="back-nav"><a href="/">← Back</a></nav>
+    <div class="page-identity">
+      <img src="/icons/open-source.png" alt="Open-source"/>Open-source
+    </div>
+  </header>
+
+  <div class="section">
+    <div class="page-banner">
+      <div class="page-banner-text">
+        <span class="banner-label">🛠️ &nbsp;Tools · Operators · Bots · Projects</span>
+        <h1>Open-source projects I've built and contributed to.</h1>
+        <p>A mix of DevOps tooling, Kubernetes operators, AWS utilities, and side projects — mostly written in Go, Python, and JavaScript.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>Projects</h2>
+    <ul>
+      <li><a href="https://github.com/tuladhar/adns-ruby" target="_blank">adns-ruby</a> – Ruby-interface to GNU adns library, written in C.</li>
+      <li><a href="https://github.com/tuladhar/cleanup-aws-access-keys" target="_blank">cleanup-aws-access-key</a> – Clean unused AWS access keys, written in Go.</li>
+      <li><a href="https://github.com/tuladhar/gmail-labels-as-tabs" target="_blank">gmail-labels-as-tabs</a> – Chrome extension to organize Gmail inbox, written in Javascript.</li>
+      <li><a href="https://github.com/tuladhar/ssl-handshake" target="_blank">ssl-handshake</a> – SSL/TLS handshake latency testing tool, written in Go.</li>
+      <li><a href="https://github.com/giantswarm/teleport-operator" target="_blank">teleport-operator</a> – Kubernetes operator for Teleport, written in Go.</li>
+      <li><a href="https://github.com/tuladhar/aws-whats-new-bot" target="_blank">aws-whats-new-bot</a> – Twitter bot for posting AWS news, written in Go.</li>
+      <li><a href="https://github.com/tuladhar/cfradarnp" target="_blank">cfradarnp</a> – Twitter bot for posting Internet trends for Nepal, written in Python, Javascript.</li>
+      <li><a href="https://github.com/tuladhar/k8s-backup-mongodb" target="_blank">k8s-backup-mongodb</a> – Schedules MongoDB backup to AWS S3 using Kubernetes CronJob.</li>
+      <li><a href="https://himalisamay.com" target="_blank">himalisamay.com</a> – Official Himali Samay Website - Nepali Brand Watches.</li>
+      <li><a href="https://quiz.purutuladhar.com/" target="_blank">quiz.purutuladhar.com</a> – Free Cloud Certifications Quiz.</li>
+      <li><a href="https://k8s-issues.purutuladhar.com" target="_blank">k8s-issues.purutuladhar.com</a> – Kubernetes Production Issues Explorer.</li>
+      <li><a href="https://purutuladhar.com/kubernetes-periodic-table" target="_blank">kubernetes-periodic-table</a> – Interactive Kubernetes Periodic Table.</li>
+      <li class="abandoned"><a href="https://jobpayena.fyi" target="_blank">jobpayena.fyi</a> – Tracking tech jobs in Nepal (Kamal, NocoDB).</li>
+      <li class="abandoned"><a href="https://certs.discount" target="_blank">certs.discount</a> – Making tech certifications affordable (Kamal, NocoDB).</li>
+    </ul>
+    <p><a href="https://github.com/tuladhar" target="_blank">See more on GitHub →</a></p>
+  </div>
+
+  <footer>
+    <p>
+      Made by <a href="/">Puru Tuladhar</a> ·
+      <a href="mailto:hello@purutuladhar.com">hello@purutuladhar.com</a> ·
+      <a href="https://www.linkedin.com/in/ptuladhar3/" target="_blank">LinkedIn</a> ·
+      <a href="https://x.com/ptuladhar3" target="_blank">X</a>
+    </p>
+  </footer>
+
+  <script async src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,359 +1,430 @@
 
 /* src/styles.css */
 
+/* Design tokens – inspired by thiings.co */
+:root {
+  --background: #ffffff;
+  --foreground: #111111;
+  --muted: #6b7280;
+  --muted-bg: #f9fafb;
+  --border: #e5e7eb;
+  --primary: #326CE5;
+  --font-sans: 'Geist', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --radius-sm: 4px;
+  --radius: 8px;
+  --radius-lg: 12px;
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.07), 0 2px 4px -2px rgba(0, 0, 0, 0.05);
+  --shadow-inset: 0 -4px 16px -4px rgba(0, 0, 0, 0.08);
+  --transition: 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
 /* General body styles */
 body {
-    font-family: 'Inter', sans-serif; /* Use Inter font */
-    margin: 0;
-    padding: 0;
-    color: #333;
-    height: 100vh; /* Full viewport height */
-    background-size: 400% 400%; /* Allow for smooth animation */
-    animation: gradientAnimation 10s ease infinite; /* Animation for the gradient */
-    position: relative;
-    overflow: auto;
-    background-color: #f8f8f8 !important;
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.7;
+  margin: 0;
+  padding: 0;
+  color: var(--foreground);
+  background-color: var(--background);
+  height: 100vh;
+  overflow: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 /* Header styles */
 header {
-    display: flex;
-    justify-content: center; /* Space between items */
-    align-items: center;
-    padding: 20px;
-    background-color: #f8f8f8;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 16px 24px;
+  background-color: var(--background);
+  border-bottom: 1px solid var(--border);
+  position: relative;
+}
+
+/* Sub-page header with back nav */
+header:has(nav.back-nav) {
+  justify-content: space-between;
+}
+
+header nav.back-nav {
+  display: flex;
+  align-items: center;
+  flex: 1;
+}
+
+header nav.back-nav a {
+  font-size: 14px;
+  color: var(--muted);
+  text-decoration: none;
+  font-weight: 500;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: color var(--transition), background-color var(--transition);
+}
+header nav.back-nav a:hover {
+  color: var(--foreground);
+  background-color: var(--muted-bg);
+  text-decoration: none;
+}
+
+.page-identity {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--muted);
+  flex: 1;
+  justify-content: center;
+}
+
+.page-identity img {
+  width: 28px;
+  height: 28px;
+}
+
+/* Spacer to balance the back nav on the right */
+header:has(nav.back-nav)::after {
+  content: '';
+  flex: 1;
 }
 
 /* Main title styles */
 h1 {
-    font-weight: bold;
-    font-size: clamp(16px, 2.5vw + 1rem, 18px); /* Responsive font size */
-    margin: 0;
+  font-weight: 700;
+  font-size: clamp(16px, 2.5vw + 1rem, 18px);
+  margin: 0;
+  letter-spacing: -0.01em;
 }
 
 /* Menu toggle button styles */
 .menu-toggle {
-    display: block; /* Hidden by default */
-    font-size: 28px;
-    min-height: 40px;
-    cursor: pointer;
-    margin-left: auto; /* Push the hamburger menu to the right */
+  display: block;
+  font-size: 28px;
+  min-height: 40px;
+  cursor: pointer;
+  margin-left: auto;
+  color: var(--foreground);
 }
 
 /* Close icon styles */
 .close-icon {
-    display: none; /* Hide close icon by default */
+  display: none;
 }
 
 /* Navigation styles */
 nav {
-    display: flex;
-    justify-content: space-between; /* Space between items */
-    align-items: center;
-    justify-content: center; /* Center items vertically */
-    height: 100%; /* Full height */
-    transition: max-height 0.5s ease-in-out;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  transition: max-height 0.5s ease-in-out;
 }
 
 /* Active navigation styles */
 nav.active {
-    display: flex; /* Show nav when active */
-    animation: reveal 0.5s ease-in-out forwards;
+  display: flex;
+  animation: reveal 0.5s ease-in-out forwards;
 }
 
 nav.active li {
-    display: flex;
-    justify-content: center;
+  display: flex;
+  justify-content: center;
 }
 
 /* Reveal animation keyframes */
 @keyframes reveal {
-    from {
-        max-height: 0;
-        opacity: 0;
-    }
-    to {
-        max-height: 500px; /* Match this with the max-height in nav.active */
-        opacity: 1;
-    }
+  from {
+    max-height: 0;
+    opacity: 0;
+  }
+  to {
+    max-height: 500px;
+    opacity: 1;
+  }
 }
 
 /* Navigation title styles */
 .nav-title {
-    font-weight: bold; /* Make the title bold */
-    margin-right: auto; /* Push the title to the left */
-    padding-right: 20px; /* Add some space to the right */
+  font-weight: 600;
+  margin-right: auto;
+  padding-right: 20px;
 }
 
 /* Navigation list styles */
 nav ul {
-    list-style-type: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    justify-content: center; /* Center the nav items */
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  gap: 4px;
 }
 
 /* Navigation list item styles */
 nav ul li {
-    margin: 0 20px; /* Equal margin on both sides */
-    display: flex;
-    align-items: center;
+  margin: 0 12px;
+  display: flex;
+  align-items: center;
 }
 
 /* Link styles */
 #nav-links a {
-    text-decoration: none; /* Remove underline */
-    font-weight: bold; /* Bold text */
-    display: flex;
-    align-items: center;
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 14px;
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  transition: color var(--transition), background-color var(--transition);
 }
 
 #nav-links li .lucide {
-    margin-right: 4px;
+  margin-right: 4px;
 }
 
 #nav-links a:hover {
-    text-decoration: underline;
+  color: var(--foreground);
+  text-decoration: none;
+  background-color: var(--muted-bg);
 }
 
 /* Navigation link styles */
 nav ul li a {
-    text-decoration: none;
-    cursor: pointer;
-    text-decoration: underline;
+  text-decoration: none;
+  cursor: pointer;
 }
 
 /* Main content styles */
 main {
-    max-width: 950px; /* Adjusted width for better alignment */
-    margin: 10px auto; /* Center the main content */
-    padding: 10px;
+  max-width: 680px;
+  margin: 48px auto;
+  padding: 0 24px;
 }
 
 h3 {
-    color: #5683a2;
+  color: var(--primary);
 }
 
-h2,.hi,.devops {
-    color: #454545;
+h2, .hi, .devops {
+  color: var(--foreground);
 }
 
 /* Subheading styles */
-h2,h3 {
-    font-size: clamp(24px, 3vw + 1rem, 28px); /* Responsive font size */
-    margin-top: 0;
-    text-align: center; /* Center the name */
+h2, h3 {
+  font-size: clamp(22px, 3vw + 1rem, 26px);
+  margin-top: 0;
+  text-align: center;
+  letter-spacing: -0.02em;
+  font-weight: 700;
 }
 
 h2 .lucide {
-    width: 32px;
-    height: 32px;
+  width: 28px;
+  height: 28px;
 }
 
 /* Smaller heading styles */
 h3 {
-    font-size: clamp(20px, 2.5vw + 1rem, 24px); /* Responsive font size */
+  font-size: clamp(18px, 2.5vw + 1rem, 22px);
 }
 
 /* Paragraph styles */
 p {
-    font-size: clamp(14px, 0.875rem + ((1vw - 3.2px) * 0.455), 18px); /* Responsive font size */
-    line-height: 1.4; /* Line height */
+  font-size: clamp(14px, 0.875rem + ((1vw - 3.2px) * 0.455), 17px);
+  line-height: 1.7;
+  color: #333;
 }
 
 /* List item styles */
 li {
-    font-size: clamp(14px, 0.875rem + ((1vw - 3.2px) * 0.455), 20px); /* Responsive font size */
-    line-height: 1.4; /* Line height */
+  font-size: clamp(14px, 0.875rem + ((1vw - 3.2px) * 0.455), 17px);
+  line-height: 1.7;
+  color: #333;
 }
 
 /* Footer styles */
 footer {
-    text-align: center;
-    padding: 20px;
-    background-color: #f8f8f8;
-    position: relative;
-    bottom: 0;
-    width: 100%;
+  text-align: center;
+  padding: 20px;
+  background-color: var(--background);
+  border-top: 1px solid var(--border);
+  position: relative;
+  bottom: 0;
+  width: 100%;
 }
 
 /* Mobile Styles */
 @media (max-width: 768px) {
-    nav {
-        display: none; /* Hide nav by default */
-        flex-direction: column; /* Stack items vertically */
-        position: absolute;
-        top: 60px; /* Position below the header */
-        right: 0;
-        background-color: #f8f8f8;
-        width: 100%;
-        z-index: 1;
-        transition: max-height 0.3s ease-in-out; /* Smooth transition */
-        overflow: hidden; /* Hide overflow */
-        max-height: 0; /* Start with height 0 */
-    }
+  nav {
+    display: none;
+    flex-direction: column;
+    position: absolute;
+    top: 60px;
+    right: 0;
+    background-color: var(--background);
+    border-bottom: 1px solid var(--border);
+    width: 100%;
+    z-index: 1;
+    transition: max-height 0.3s ease-in-out;
+    overflow: hidden;
+    max-height: 0;
+  }
 
-    nav.active {
-        display: flex; /* Show nav when active */
-        max-height: 200px; /* Set a max height for the expanded menu */
-    }
+  nav.active {
+    display: flex;
+    max-height: 260px;
+  }
 
-    nav ul {
-        flex-direction: column; /* Stack links vertically */
-        width: 100%;
-    }
+  nav ul {
+    flex-direction: column;
+    width: 100%;
+  }
 
-    nav ul li {
-        margin: 10px 0; /* Space between links */
-        text-align: center; /* Center the links */
-    }
+  nav ul li {
+    margin: 8px 0;
+    text-align: center;
+  }
 
-    .nav-title {
-        display: block; /* Ensure title is visible in mobile view */
-        text-align: center; /* Center the title */
-        padding: 10px 0; /* Add some padding */
-    }
+  .nav-title {
+    display: block;
+    text-align: center;
+    padding: 10px 0;
+  }
+
+  main {
+    margin: 32px auto;
+  }
 }
 
 /* Tablet and Desktop Styles */
 @media (min-width: 769px) {
-    h1 {
-        font-size: clamp(16px, 2.5vw + 1rem, 18px); /* Larger font size for desktop */
-    }
+  h1 {
+    font-size: clamp(16px, 2.5vw + 1rem, 18px);
+  }
 
-    h2 {
-        font-size: clamp(28px, 3vw + 1rem, 36px); /* Larger font size for desktop */
-    }
+  h2 {
+    font-size: clamp(26px, 3vw + 1rem, 32px);
+  }
 
-    h3 {
-        font-size: clamp(24px, 2.5vw + 1rem, 28px); /* Larger font size for desktop */
-    }
+  h3 {
+    font-size: clamp(20px, 2.5vw + 1rem, 24px);
+  }
 
-    p {
-        font-size: clamp(16px, 0.875rem + ((1vw - 3.2px) * 0.455), 20px); /* Larger font size for desktop */
-    }
+  p {
+    font-size: clamp(15px, 0.875rem + ((1vw - 3.2px) * 0.455), 18px);
+  }
 
-    .menu-toggle {
-        display: none; /* Hide the hamburger icon on larger screens */
-    }
-}
-
-/* Custom link styles */
-.custom-link {
-    color: #0693e3; /* Set link color to sky blue */
-    text-decoration: none; /* Remove underline */
-    cursor: pointer;
+  .menu-toggle {
+    display: none;
+  }
 }
 
 /* General link styles */
 a {
-    /* Set link color */
-    /* color: #0693e3; */
-    color: #5683a2;
-    font-weight: bold;
-    text-decoration: none; /* Dotted underline */
-    cursor: pointer;
-}
-a:hover {
-    text-decoration: underline;
+  color: var(--primary);
+  font-weight: 500;
+  text-decoration: none;
+  cursor: pointer;
+  transition: color var(--transition), opacity var(--transition);
 }
 
-/* Visited link styles */
-/* a:visited { */
-    /* Keep the same color for visited links */
-    /* color: red;  */
-/* } */
+a:hover {
+  text-decoration: underline;
+  opacity: 0.85;
+}
 
 /* Custom link styles */
 .custom-link {
-    color: #333;
-    text-decoration: none; /* Add underline on hover for better UX */
+  color: var(--foreground);
+  text-decoration: none;
 }
 .custom-link:hover {
-    text-decoration: underline; /* Add underline on hover for better UX */
-
-    cursor: pointer;
+  text-decoration: underline;
+  cursor: pointer;
 }
 
 /* Avatar styles */
 .avatar {
-    display: block; /* Center the image */
-    margin: 0 auto 20px; /* Center and add space below */
-    width: 112px; /* Set a width for the avatar */
-    height: 112px; /* Set a height for the avatar */
-    border-radius: 0%; /* Make the image rounded */
-    object-fit: cover; /* Ensure the image covers the area */
+  display: block;
+  margin: 0 auto 24px;
+  width: 112px;
+  height: 112px;
+  border-radius: var(--radius);
+  object-fit: cover;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
 }
 
-/* small {
-    color: #3b3b3b;
-} */
-
-a.github,a.twitter,a.cks-handbook,a.kubestronaut,a.aws-certified,a.linkedin,a.periodic-table {
-    padding: 0px 5px 0px 5px;
-    color: white;
-    border-radius: 4px;
+a.github, a.twitter, a.cks-handbook, a.kubestronaut, a.aws-certified, a.linkedin, a.periodic-table {
+  padding: 1px 6px;
+  color: white;
+  border-radius: var(--radius-sm);
+  font-size: 0.92em;
+  font-weight: 600;
+  letter-spacing: 0.01em;
 }
 
-a.github,a.twitter {
-    background-color: #444;
+a.github, a.twitter {
+  background-color: #444;
 }
 
 .interactive {
-    /* background: linear-gradient(90deg, #a78bfa, #60a5fa); */
-    background: linear-gradient(90deg, #a78bfa);
-        padding: 0px 5px 0px 5px;
-    color: white;
-    border-radius: 4px;
-    margin-right: 5px;
+  background: linear-gradient(90deg, #a78bfa);
+  padding: 1px 6px;
+  color: white;
+  border-radius: var(--radius-sm);
+  margin-right: 5px;
 }
 
 .kubestronaut {
-    /* background: linear-gradient(90deg, #a78bfa, #60a5fa); */
-    background-color: #326CE5;
-    padding: 0px 5px 0px 5px;
-    color: white;
-    border-radius: 4px;
+  background-color: #326CE5;
+  padding: 1px 6px;
+  color: white;
+  border-radius: var(--radius-sm);
 }
 
 .periodic-table {
-    /* background: linear-gradient(90deg, #a78bfa, #60a5fa); */
-    background-color: #FF9900;
-    padding: 0px 5px 0px 5px;
-    color: white;
-    border-radius: 4px;
+  background-color: #FF9900;
+  padding: 1px 6px;
+  color: white;
+  border-radius: var(--radius-sm);
 }
 
 a.cks-handbook {
-    /* background: linear-gradient(90deg, #a78bfa, #60a5fa); */
-    background: linear-gradient(90deg, #a78bfa);
+  background: linear-gradient(90deg, #a78bfa);
 }
 
 a.kubestronaut {
-    background-color: #326CE5;
+  background-color: #326CE5;
 }
 
 a.aws-certified {
-    background-color: #FF9900;
+  background-color: #FF9900;
 }
 
 a.linkedin {
-    background-color:  #0A66C2;
+  background-color: #0A66C2;
 }
 
 .heading {
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .heading img {
-    width: 50px;
+  width: 50px;
 }
 
 .wave-emoji {
-    font-size: 30px;
+  font-size: 28px;
 }
 
 .abandoned {

--- a/styles.css
+++ b/styles.css
@@ -358,8 +358,8 @@ a:hover {
   height: 112px;
   border-radius: var(--radius);
   object-fit: cover;
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow);
+  #border: 1px solid var(--border);
+  #box-shadow: var(--shadow);
 }
 
 a.github, a.twitter, a.cks-handbook, a.kubestronaut, a.aws-certified, a.linkedin, a.periodic-table {

--- a/training/index.html
+++ b/training/index.html
@@ -12,15 +12,26 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest">
 
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 
   <style>
+    :root {
+      --background: #ffffff;
+      --foreground: #111111;
+      --muted: #6b7280;
+      --border: #e5e7eb;
+      --muted-bg: #f9fafb;
+      --font-sans: 'Geist', system-ui, -apple-system, sans-serif;
+      --radius: 8px;
+      --transition: 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+    }
     * { box-sizing: border-box; margin: 0; padding: 0; }
 
     body {
-      font-family: 'Inter', sans-serif;
-      background: #fff;
-      color: #333;
+      font-family: var(--font-sans);
+      background: var(--background);
+      color: var(--foreground);
+      -webkit-font-smoothing: antialiased;
       font-size: 16px;
       line-height: 1.7;
       max-width: 680px;
@@ -30,34 +41,63 @@
 
     header {
       margin-bottom: 3rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
     }
 
-    header nav a {
+    header nav.back-nav a {
       font-size: 14px;
-      color: #888;
+      color: var(--muted);
+      text-decoration: none;
+      font-weight: 500;
+      padding: 4px 8px;
+      border-radius: 4px;
+      transition: color var(--transition), background-color var(--transition);
+    }
+    header nav.back-nav a:hover {
+      color: var(--foreground);
+      background-color: var(--muted-bg);
       text-decoration: none;
     }
-    header nav a:hover { color: #333; }
+
+    .page-identity {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 14px;
+      font-weight: 500;
+      color: var(--muted);
+      flex: 1;
+      justify-content: center;
+    }
+
+    .page-identity img {
+      width: 28px;
+      height: 28px;
+    }
 
     h1 {
       font-size: 22px;
       font-weight: 700;
-      color: #111;
+      color: var(--foreground);
       margin-bottom: 0.5rem;
       line-height: 1.3;
+      letter-spacing: -0.02em;
     }
 
     h2 {
       font-size: 18px;
       font-weight: 700;
-      color: #111;
+      color: var(--foreground);
       margin: 2.5rem 0 0.75rem;
+      letter-spacing: -0.01em;
     }
 
     h3 {
       font-size: 15px;
-      font-weight: 700;
-      color: #111;
+      font-weight: 600;
+      color: var(--foreground);
       margin: 1.25rem 0 0.4rem;
     }
 
@@ -67,27 +107,60 @@
     }
 
     a {
-      color: #0066cc;
+      color: #326CE5;
       text-decoration: none;
+      font-weight: 500;
+      transition: opacity var(--transition);
     }
-    a:hover { text-decoration: underline; }
+    a:hover { text-decoration: underline; opacity: 0.85; }
 
-    .avatar {
-      width: 80px;
-      height: 80px;
-      border-radius: 50%;
-      margin-bottom: 1rem;
-      display: block;
+    .page-banner {
+      width: 100%;
+      border-radius: var(--radius);
+      margin-bottom: 1.75rem;
+      padding: 2rem;
+      display: flex;
+      align-items: flex-start;
+      background: var(--muted-bg);
+      border: 1px solid var(--border);
+    }
+
+    .page-banner-text {
+      color: var(--foreground);
+    }
+
+    .page-banner-text h1 {
+      font-size: 22px;
+      font-weight: 700;
+      color: var(--foreground);
+      line-height: 1.3;
+      margin-bottom: 0.75rem;
+      letter-spacing: -0.02em;
+    }
+
+    .page-banner-text p {
+      font-size: 14px;
+      color: #444;
+      line-height: 1.6;
+      margin-bottom: 0;
+    }
+
+    .page-banner-text .banner-label {
+      font-size: 13px;
+      font-weight: 600;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--muted);
     }
 
     .intro {
-      border-bottom: 1px solid #eee;
+      border-bottom: 1px solid var(--border);
       padding-bottom: 2rem;
       margin-bottom: 2rem;
     }
 
     .section {
-      border-bottom: 1px solid #eee;
+      border-bottom: 1px solid var(--border);
       padding-bottom: 2rem;
       margin-bottom: 2rem;
     }
@@ -110,17 +183,17 @@
     .cert-badge {
       display: inline-block;
       padding: 3px 10px;
-      border: 1px solid #ddd;
+      border: 1px solid var(--border);
       border-radius: 20px;
       font-size: 13px;
-      font-weight: 700;
-      color: #333;
-      background: #f9f9f9;
+      font-weight: 600;
+      color: var(--foreground);
+      background: var(--muted-bg);
     }
 
     .social-proof {
-      background: #f7f7f7;
-      border-left: 3px solid #111;
+      background: var(--muted-bg);
+      border-left: 3px solid var(--foreground);
       padding: 1rem 1.25rem;
       margin: 1rem 0;
       border-radius: 0 4px 4px 0;
@@ -132,7 +205,7 @@
     }
     .social-proof .source {
       font-size: 13px;
-      color: #888;
+      color: var(--muted);
       margin-top: 0.4rem;
     }
 
@@ -155,11 +228,11 @@
       top: 2px;
       width: 22px;
       height: 22px;
-      background: #111;
+      background: var(--foreground);
       color: #fff;
       border-radius: 50%;
       font-size: 12px;
-      font-weight: 700;
+      font-weight: 600;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -171,23 +244,23 @@
     }
     .module-list li {
       padding: 0.6rem 0;
-      border-bottom: 1px solid #f0f0f0;
+      border-bottom: 1px solid var(--border);
       color: #444;
     }
     .module-list li:last-child { border-bottom: none; }
-    .module-list li strong { color: #111; }
+    .module-list li strong { color: var(--foreground); }
 
     .note {
       font-size: 14px;
-      color: #888;
+      color: var(--muted);
       font-style: italic;
     }
 
     .form-section label {
       display: block;
       font-size: 14px;
-      font-weight: 700;
-      color: #333;
+      font-weight: 600;
+      color: var(--foreground);
       margin-bottom: 4px;
       margin-top: 1rem;
     }
@@ -195,61 +268,72 @@
     .form-section textarea,
     .form-section select {
       width: 100%;
-      border: 1px solid #ccc;
-      border-radius: 4px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
       padding: 8px 10px;
       font-size: 14px;
-      font-family: 'Inter', sans-serif;
-      color: #333;
+      font-family: var(--font-sans);
+      color: var(--foreground);
+      background: var(--background);
       outline: none;
+      transition: border-color var(--transition);
     }
     .form-section input:focus,
     .form-section textarea:focus,
     .form-section select:focus {
-      border-color: #0066cc;
+      border-color: #326CE5;
     }
     .form-section textarea { resize: vertical; min-height: 80px; }
 
     .btn {
       display: inline-block;
       margin-top: 1rem;
-      padding: 10px 20px;
-      background: #111;
+      padding: 9px 20px;
+      background: var(--foreground);
       color: #fff;
       font-size: 14px;
-      font-weight: 700;
+      font-weight: 600;
       border: none;
-      border-radius: 4px;
+      border-radius: 6px;
       cursor: pointer;
-      font-family: 'Inter', sans-serif;
+      font-family: var(--font-sans);
+      transition: opacity var(--transition), transform var(--transition);
     }
-    .btn:hover { background: #333; }
+    .btn:hover { opacity: 0.85; }
+    .btn:active { transform: scale(0.97); }
 
     footer {
       margin-top: 3rem;
       padding-top: 1.5rem;
-      border-top: 1px solid #eee;
+      border-top: 1px solid var(--border);
       font-size: 14px;
-      color: #888;
+      color: var(--muted);
     }
-    footer a { color: #888; }
-    footer a:hover { color: #333; }
+    footer a { color: var(--muted); font-weight: 500; }
+    footer a:hover { color: var(--foreground); text-decoration: none; }
   </style>
 </head>
 <body>
 
   <header>
-    <nav><a href="/">← purutuladhar.com</a></nav>
+    <nav class="back-nav"><a href="/">← Back</a></nav>
+    <div class="page-identity">
+      <img src="/icons/training.png" alt="Training"/>Training
+    </div>
   </header>
 
   <!-- INTRO -->
   <div class="intro">
-    <img src="/avatar.png" alt="Puru Tuladhar" class="avatar">
-    <h1>Kubernetes training for teams and corporates in Nepal.</h1>
-    <p>
-      I run hands-on, instructor-led Kubernetes training programs for engineering teams —
-      built around real-world administration and aligned with CNCF certifications.
-    </p>
+    <div class="page-banner">
+      <div class="page-banner-text">
+        <span class="banner-label">☸️ &nbsp;Kubernetes · CKA · CKAD · CKS · Nepal</span>
+        <h1>Kubernetes training for teams and corporates in Nepal.</h1>
+        <p>
+          I run hands-on, instructor-led Kubernetes training programs for engineering teams —
+          built around real-world administration and aligned with CNCF certifications.
+        </p>
+      </div>
+    </div>
     <div class="cert-badges">
       <span class="cert-badge">CKA</span>
       <span class="cert-badge">CKAD</span>


### PR DESCRIPTION
## Summary

- Switch font from Inter to **Geist** across all pages
- Add CSS design tokens via custom properties (colors, spacing, radius, shadows, transitions) inspired by thiings.co
- Consistent header with **← Back** nav and centered page identity (icon + name) on all sub-pages
- Rebuild blogs, books, and open-source pages using hire page as template — consistent layout, banner, and styling
- Add muted background banner to hire and training pages
- Clean up nav hover effects, link styles, and button interactions

## Pages updated
- `index.html` — Geist font, updated styles
- `styles.css` — full design token overhaul
- `devops/index.html` — banner, back nav, page identity
- `training/index.html` — banner, back nav, page identity
- `blogs/index.html` — full rebuild matching hire page structure
- `books/index.html` — full rebuild matching hire page structure
- `open-source/index.html` — full rebuild matching hire page structure