### PR TITLE
Add Web3Forms integration for contact forms

### DIFF
--- a/devops/index.html
+++ b/devops/index.html
@@ -421,53 +421,65 @@
 
     <!-- COMPANY -->
     <div class="form-panel active" id="panel-company">
-      <label>Company name</label>
-      <input type="text" id="c-company" placeholder="Acme Technologies">
+      <form action="https://api.web3forms.com/submit" method="POST" onsubmit="handleSubmit(event, this)">
+        <input type="hidden" name="access_key" value="1fff25d6-93ab-4397-b808-1921111e6e8f">
+        <input type="hidden" name="subject" value="DevOps Hiring Inquiry">
+        <input type="hidden" name="from_name" value="purutuladhar.com – Hire">
 
-      <label>Your name &amp; role</label>
-      <input type="text" id="c-name" placeholder="Priya Shrestha, CTO">
+        <label>Company name</label>
+        <input type="text" name="company" placeholder="Acme Technologies">
 
-      <label>Email</label>
-      <input type="email" id="c-email" placeholder="priya@acme.com.np">
+        <label>Your name &amp; role</label>
+        <input type="text" name="name" placeholder="Priya Shrestha, CTO">
 
-      <label>What's your current tech stack?</label>
-      <input type="text" id="c-stack" placeholder="AWS, Kubernetes, Terraform, GitHub Actions...">
+        <label>Email</label>
+        <input type="email" name="email" placeholder="priya@acme.com.np" required>
 
-      <label>What's the biggest DevOps problem you're facing right now?</label>
-      <textarea id="c-problem" placeholder="No CI/CD, manual deployments, scaling issues, no one owns infra..."></textarea>
+        <label>What's your current tech stack?</label>
+        <input type="text" name="stack" placeholder="AWS, Kubernetes, Terraform, GitHub Actions...">
 
-      <label>Which option interests you?</label>
-      <select id="c-option">
-        <option value="">Select...</option>
-        <option>Placement only</option>
-        <option>Placement + Mentorship</option>
-        <option>Not sure yet</option>
-      </select>
+        <label>What's the biggest DevOps problem you're facing right now?</label>
+        <textarea name="problem" placeholder="No CI/CD, manual deployments, scaling issues, no one owns infra..."></textarea>
 
-      <button class="btn" onclick="submitForm('company')">Send →</button>
+        <label>Which option interests you?</label>
+        <select name="option">
+          <option value="">Select...</option>
+          <option>Placement only</option>
+          <option>Placement + Mentorship</option>
+          <option>Not sure yet</option>
+        </select>
+
+        <button type="submit" class="btn">Send →</button>
+      </form>
     </div>
 
     <!-- ENGINEER -->
     <div class="form-panel" id="panel-engineer">
-      <label>Your name</label>
-      <input type="text" id="e-name" placeholder="Bikash Thapa">
+      <form action="https://api.web3forms.com/submit" method="POST" onsubmit="handleSubmit(event, this)">
+        <input type="hidden" name="access_key" value="1fff25d6-93ab-4397-b808-1921111e6e8f">
+        <input type="hidden" name="subject" value="DevOps Engineer Application">
+        <input type="hidden" name="from_name" value="purutuladhar.com – Hire">
 
-      <label>Email</label>
-      <input type="email" id="e-email" placeholder="bikash@gmail.com">
+        <label>Your name</label>
+        <input type="text" name="name" placeholder="Bikash Thapa">
 
-      <label>Current role / experience level</label>
-      <input type="text" id="e-role" placeholder="Junior DevOps, 1 yr / transitioning from backend dev">
+        <label>Email</label>
+        <input type="email" name="email" placeholder="bikash@gmail.com" required>
 
-      <label>Tools you're comfortable with</label>
-      <input type="text" id="e-tools" placeholder="Linux, Docker, basic AWS...">
+        <label>Current role / experience level</label>
+        <input type="text" name="role" placeholder="Junior DevOps, 1 yr / transitioning from backend dev">
 
-      <label>What do you want to get better at?</label>
-      <textarea id="e-goal" placeholder="Kubernetes, CI/CD pipelines, Terraform, cloud architecture..."></textarea>
+        <label>Tools you're comfortable with</label>
+        <input type="text" name="tools" placeholder="Linux, Docker, basic AWS...">
 
-      <label>LinkedIn or GitHub (optional)</label>
-      <input type="url" id="e-link" placeholder="https://github.com/...">
+        <label>What do you want to get better at?</label>
+        <textarea name="goals" placeholder="Kubernetes, CI/CD pipelines, Terraform, cloud architecture..."></textarea>
 
-      <button class="btn" onclick="submitForm('engineer')">Send →</button>
+        <label>LinkedIn or GitHub (optional)</label>
+        <input type="url" name="link" placeholder="https://github.com/...">
+
+        <button type="submit" class="btn">Send →</button>
+      </form>
     </div>
   </div>
 
@@ -489,32 +501,22 @@
       document.getElementById('panel-' + tab).classList.add('active');
     }
 
-    function submitForm(type) {
-      let subject, body;
-      if (type === 'company') {
-        subject = 'DevOps Hiring – ' + (document.getElementById('c-company').value || 'Inquiry');
-        body = [
-          'Company: ' + document.getElementById('c-company').value,
-          'Name/Role: ' + document.getElementById('c-name').value,
-          'Email: ' + document.getElementById('c-email').value,
-          'Stack: ' + document.getElementById('c-stack').value,
-          'Problem: ' + document.getElementById('c-problem').value,
-          'Option: ' + document.getElementById('c-option').value,
-        ].join('\n');
+    async function handleSubmit(e, form) {
+      e.preventDefault();
+      const btn = form.querySelector('button[type="submit"]');
+      btn.disabled = true;
+      btn.textContent = 'Sending…';
+      const res = await fetch('https://api.web3forms.com/submit', {
+        method: 'POST',
+        body: new FormData(form)
+      });
+      if (res.ok) {
+        btn.textContent = 'Sent ✓';
+        form.reset();
       } else {
-        subject = 'DevOps Engineer – ' + (document.getElementById('e-name').value || 'Application');
-        body = [
-          'Name: ' + document.getElementById('e-name').value,
-          'Email: ' + document.getElementById('e-email').value,
-          'Role/Exp: ' + document.getElementById('e-role').value,
-          'Tools: ' + document.getElementById('e-tools').value,
-          'Goals: ' + document.getElementById('e-goal').value,
-          'Link: ' + document.getElementById('e-link').value,
-        ].join('\n');
+        btn.textContent = 'Failed — try again';
+        btn.disabled = false;
       }
-      window.location.href = 'mailto:hello@purutuladhar.com'
-        + '?subject=' + encodeURIComponent(subject)
-        + '&body=' + encodeURIComponent(body);
     }
   </script>
 </body>

--- a/training/index.html
+++ b/training/index.html
@@ -453,40 +453,46 @@
     <h2>Get in touch</h2>
     <p>Tell me about your team and what you're aiming for. I'll get back within 24–48 hours.</p>
 
-    <label>Company / Organisation name</label>
-    <input type="text" id="t-company" placeholder="Acme Technologies">
+    <form action="https://api.web3forms.com/submit" method="POST" onsubmit="handleSubmit(event, this)">
+      <input type="hidden" name="access_key" value="455b3224-96e7-46aa-a2fc-9170c3813b24">
+      <input type="hidden" name="subject" value="Kubernetes Training Inquiry">
+      <input type="hidden" name="from_name" value="purutuladhar.com – Training">
 
-    <label>Your name &amp; role</label>
-    <input type="text" id="t-name" placeholder="Priya Shrestha, CTO">
+      <label>Company / Organisation name</label>
+      <input type="text" name="company" placeholder="Acme Technologies">
 
-    <label>Email</label>
-    <input type="email" id="t-email" placeholder="priya@acme.com.np">
+      <label>Your name &amp; role</label>
+      <input type="text" name="name" placeholder="Priya Shrestha, CTO">
 
-    <label>Team size (approximate)</label>
-    <input type="text" id="t-size" placeholder="5–10 engineers">
+      <label>Email</label>
+      <input type="email" name="email" placeholder="priya@acme.com.np" required>
 
-    <label>Current Kubernetes experience level</label>
-    <select id="t-level">
-      <option value="">Select...</option>
-      <option>Beginner — little to no Kubernetes experience</option>
-      <option>Intermediate — using Kubernetes, want to go deeper</option>
-      <option>Mixed — varies across the team</option>
-    </select>
+      <label>Team size (approximate)</label>
+      <input type="text" name="team_size" placeholder="5–10 engineers">
 
-    <label>Target certification (if any)</label>
-    <select id="t-cert">
-      <option value="">Select...</option>
-      <option>CKA – Certified Kubernetes Administrator</option>
-      <option>CKAD – Certified Kubernetes Application Developer</option>
-      <option>CKS – Certified Kubernetes Security Specialist</option>
-      <option>No certification — production readiness focus</option>
-      <option>Not sure yet</option>
-    </select>
+      <label>Current Kubernetes experience level</label>
+      <select name="experience_level">
+        <option value="">Select...</option>
+        <option>Beginner — little to no Kubernetes experience</option>
+        <option>Intermediate — using Kubernetes, want to go deeper</option>
+        <option>Mixed — varies across the team</option>
+      </select>
 
-    <label>Anything else you'd like me to know?</label>
-    <textarea id="t-notes" placeholder="Timeline, constraints, specific topics you want covered..."></textarea>
+      <label>Target certification (if any)</label>
+      <select name="target_cert">
+        <option value="">Select...</option>
+        <option>CKA – Certified Kubernetes Administrator</option>
+        <option>CKAD – Certified Kubernetes Application Developer</option>
+        <option>CKS – Certified Kubernetes Security Specialist</option>
+        <option>No certification — production readiness focus</option>
+        <option>Not sure yet</option>
+      </select>
 
-    <button class="btn" onclick="submitForm()">Send →</button>
+      <label>Anything else you'd like me to know?</label>
+      <textarea name="notes" placeholder="Timeline, constraints, specific topics you want covered..."></textarea>
+
+      <button type="submit" class="btn">Send →</button>
+    </form>
   </div>
 
   <footer>
@@ -500,20 +506,22 @@
 
   <script async src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
   <script>
-    function submitForm() {
-      const subject = 'Kubernetes Training – ' + (document.getElementById('t-company').value || 'Inquiry');
-      const body = [
-        'Company: ' + document.getElementById('t-company').value,
-        'Name/Role: ' + document.getElementById('t-name').value,
-        'Email: ' + document.getElementById('t-email').value,
-        'Team size: ' + document.getElementById('t-size').value,
-        'Experience level: ' + document.getElementById('t-level').value,
-        'Target cert: ' + document.getElementById('t-cert').value,
-        'Notes: ' + document.getElementById('t-notes').value,
-      ].join('\n');
-      window.location.href = 'mailto:training@purutuladhar.com'
-        + '?subject=' + encodeURIComponent(subject)
-        + '&body=' + encodeURIComponent(body);
+    async function handleSubmit(e, form) {
+      e.preventDefault();
+      const btn = form.querySelector('button[type="submit"]');
+      btn.disabled = true;
+      btn.textContent = 'Sending…';
+      const res = await fetch('https://api.web3forms.com/submit', {
+        method: 'POST',
+        body: new FormData(form)
+      });
+      if (res.ok) {
+        btn.textContent = 'Sent ✓';
+        form.reset();
+      } else {
+        btn.textContent = 'Failed — try again';
+        btn.disabled = false;
+      }
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Replace `mailto:` form submission on hire and training pages with async POST to [Web3Forms](https://web3forms.com) API
- Forms now work without requiring a local email client
- Shows inline feedback: "Sending…" → "Sent ✓" on success, or "Failed — try again" on error

## Test plan
- [ ] Submit hire page form and verify email is received
- [ ] Submit training page form and verify email is received
- [ ] Verify error state displays when submission fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)